### PR TITLE
Fix permission denied issue during Package external libraries

### DIFF
--- a/script/repackage-dylibs.rb
+++ b/script/repackage-dylibs.rb
@@ -89,6 +89,7 @@ def repackage_dependency(dep)
 
     note "Copying #{dep[:path]} to TARGET_FRAMEWORKS_PATH"
     FileUtils.cp dep[:path], TARGET_FRAMEWORKS_PATH
+    FileUtils.chmod "u=wr", dep[:path]
 
     out = `install_name_tool -change #{dep.path} "@rpath/#{dep.name}" #{dep.executable}`
     if $? != 0


### PR DESCRIPTION
This happens because `libssl.1.0.0.dylib` is installed mode 444 from Homebrew in /usr/local/lib
(or at least was on my brand new Mojave install).  So when `FileUtils.cp` makes a copy of it,
it stays readonly, so `install_name_tool` fails:

```
note: Packaging libcrypto.1.0.0.dylib…
warning: /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib already in Frameworks directory, removing
note: Copying /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib to TARGET_FRAMEWORKS_PATH
note: Packaging libssl.1.0.0.dylib…
warning: /usr/local/opt/openssl/lib/libssl.1.0.0.dylib already in Frameworks directory, removing
note: Copying /usr/local/opt/openssl/lib/libssl.1.0.0.dylib to TARGET_FRAMEWORKS_PATH
note: Fixing libcrypto.1.0.0.dylib install_name id…
note: Fixing libssl.1.0.0.dylib install_name id…
error: install_name_tool: can't open input file: /Users/carlb/Library/Developer/Xcode/DerivedData/GitX-ceopxklkteyyvrepxlzprsjsdegg/Build/Products/Debug/ObjectiveGit.framework/Versions/A/Frameworks/libssl.1.0.0.dylib for writing (Permission denied)
error: install_name_tool: can't lseek to offset: 0 in file: /Users/carlb/Library/Developer/Xcode/DerivedData/GitX-ceopxklkteyyvrepxlzprsjsdegg/Build/Products/Debug/ObjectiveGit.framework/Versions/A/Frameworks/libssl.1.0.0.dylib for writing (Bad file descriptor)
error: install_name_tool: can't write new headers in file: /Users/carlb/Library/Developer/Xcode/DerivedData/GitX-ceopxklkteyyvrepxlzprsjsdegg/Build/Products/Debug/ObjectiveGit.framework/Versions/A/Frameworks/libssl.1.0.0.dylib (Bad file descriptor)
error: install_name_tool: can't close written on input file: /Users/carlb/Library/Developer/Xcode/DerivedData/GitX-ceopxklkteyyvrepxlzprsjsdegg/Build/Products/Debug/ObjectiveGit.framework/Versions/A/Frameworks/libssl.1.0.0.dylib (Bad file descriptor)
error: install_name_tool failed with error pid 25708 exit 1:

```