### PR TITLE
Github runner macos-15-intel

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -17,11 +17,8 @@ jobs:
         xcode: [ 15.4, 16.2 ]
         arch: [ arm64 ]
         include:
-          - xcode: 15.2.0
-            os: macos-13
-            arch: x86_64
-          - xcode: 14.2.0
-            os: macos-13
+          - xcode: 16.4.0
+            os: macos-15-intel
             arch: x86_64
     steps:
       - name: ls Xcode


### PR DESCRIPTION
macos-13 runners are going away very soon:

'This process will begin October 1, 2025, and the image will be fully retired on December 4, 2025.'