### PR TITLE
Remove warning cmake_minimum_required

### DIFF
--- a/script/update_libgit2
+++ b/script/update_libgit2
@@ -30,7 +30,6 @@ cmake --version
 cmake -DBUILD_SHARED_LIBS:BOOL=OFF \
   -DBUILD_CLAR:BOOL=OFF \
   -DTHREADSAFE:BOOL=ON \
-  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
   ..
 cmake --build .
 


### PR DESCRIPTION
Since libgit2's CMakeLists.txt already calls cmake_minimum_required(VERSION 3.5.1) as its very first statement, the variable was always redundant. Removing it eliminates the warning.

This is the causing warning:
CMake suite maintained and supported by Kitware (kitware.com/cmake). CMake Warning (dev) at CMakeLists.txt:14 (PROJECT): cmake_minimum_required() should be called prior to this top-level project() call.

Line 690 in https://github.com/gitx/gitx/actions/runs/22541819447/job/65298081457